### PR TITLE
Фикс порчи config.json при обновлении (сброс авторизации)

### DIFF
--- a/MaxLight/ConfigManager.cs
+++ b/MaxLight/ConfigManager.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using Newtonsoft.Json;
 using Microsoft.Win32;
 using System.Windows.Forms;
@@ -11,6 +12,23 @@ namespace MaxLight
     public class ConfigManager
     {
         private static readonly object _lock = new object();
+
+        // Межпроцессная блокировка: при обновлении Velopack старый и новый процессы
+        // могут обращаться к config.json одновременно
+        private static readonly Mutex _crossProcessLock = new Mutex(false, "MaxLight_ConfigFileMutex");
+
+        private static bool AcquireFileLock()
+        {
+            try
+            {
+                return _crossProcessLock.WaitOne(TimeSpan.FromSeconds(5));
+            }
+            catch (AbandonedMutexException)
+            {
+                // Прежний процесс был убит, не освободив мьютекс — блокировка теперь наша
+                return true;
+            }
+        }
 
         // ========== ПРАВИЛЬНЫЙ ПУТЬ К CONFIG.JSON ==========
         private static string GetConfigPath()
@@ -103,22 +121,62 @@ namespace MaxLight
         {
             lock (_lock)
             {
-                string configPath = GetConfigPath();
-
-                if (!File.Exists(configPath))
-                {
-                    return new ConfigData();
-                }
-
+                bool locked = AcquireFileLock();
                 try
                 {
-                    string json = File.ReadAllText(configPath);
-                    return JsonConvert.DeserializeObject<ConfigData>(json) ?? new ConfigData();
+                    return LoadConfigCore();
                 }
-                catch
+                finally
                 {
-                    return new ConfigData();
+                    if (locked) _crossProcessLock.ReleaseMutex();
                 }
+            }
+        }
+
+        private static ConfigData LoadConfigCore()
+        {
+            string configPath = GetConfigPath();
+            string backupPath = configPath + ".bak";
+
+            if (!File.Exists(configPath))
+            {
+                // Свежая установка — либо сбой между шагами File.Replace: пробуем бэкап
+                return TryReadFile(backupPath) ?? new ConfigData();
+            }
+
+            var config = TryReadFile(configPath);
+            if (config != null) return config;
+
+            // Файл битый: сохраняем копию для диагностики, пробуем восстановиться из бэкапа
+            try
+            {
+                File.Copy(configPath, configPath + ".corrupt-" + DateTime.Now.ToString("yyyyMMdd-HHmmss"), true);
+            }
+            catch { }
+
+            config = TryReadFile(backupPath);
+            if (config != null)
+            {
+                System.Diagnostics.Debug.WriteLine("♻️ config.json битый, восстановлен из .bak");
+                try { SaveConfigCore(config); } catch { }
+                return config;
+            }
+
+            System.Diagnostics.Debug.WriteLine("⚠️ config.json битый, бэкапа нет — создан новый");
+            return new ConfigData();
+        }
+
+        private static ConfigData TryReadFile(string path)
+        {
+            if (!File.Exists(path)) return null;
+            try
+            {
+                string json = File.ReadAllText(path);
+                return JsonConvert.DeserializeObject<ConfigData>(json);
+            }
+            catch
+            {
+                return null;
             }
         }
 
@@ -126,17 +184,48 @@ namespace MaxLight
         {
             lock (_lock)
             {
+                bool locked = AcquireFileLock();
                 try
                 {
-                    string configPath = GetConfigPath();
-                    string json = JsonConvert.SerializeObject(config, Formatting.Indented);
-                    File.WriteAllText(configPath, json);
-                    System.Diagnostics.Debug.WriteLine($"💾 Config сохранен: {configPath}");
+                    SaveConfigCore(config);
+                    System.Diagnostics.Debug.WriteLine($"💾 Config сохранен: {GetConfigPath()}");
                 }
                 catch (Exception ex)
                 {
                     System.Diagnostics.Debug.WriteLine($"❌ Ошибка сохранения config.json: {ex.Message}");
                 }
+                finally
+                {
+                    if (locked) _crossProcessLock.ReleaseMutex();
+                }
+            }
+        }
+
+        private static void SaveConfigCore(ConfigData config)
+        {
+            string configPath = GetConfigPath();
+            string tempPath = configPath + ".tmp";
+            string backupPath = configPath + ".bak";
+            string json = JsonConvert.SerializeObject(config, Formatting.Indented);
+
+            // Пишем во временный файл и сбрасываем на диск ДО подмены основного:
+            // прерванная запись портит только .tmp, а config.json остаётся целым
+            using (var fs = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
+            using (var writer = new StreamWriter(fs, new UTF8Encoding(false)))
+            {
+                writer.Write(json);
+                writer.Flush();
+                fs.Flush(true);
+            }
+
+            if (File.Exists(configPath))
+            {
+                // Атомарная подмена: читатель видит либо старый, либо новый файл целиком
+                File.Replace(tempPath, configPath, backupPath, true);
+            }
+            else
+            {
+                File.Move(tempPath, configPath);
             }
         }
 

--- a/MaxLight/Form1.cs
+++ b/MaxLight/Form1.cs
@@ -81,8 +81,9 @@ namespace MaxLight
             this.FormBorderStyle = FormBorderStyle.None;
             this.FormClosing += Form1_FormClosing;
             this.Resize += Form1_Resize;
+            // ResizeEnd (WM_EXITSIZEMOVE) срабатывает и в конце перетаскивания окна,
+            // отдельный Move не нужен — он писал config.json десятки раз в секунду
             this.ResizeEnd += (s, e) => SaveWindowState();
-            this.Move += (s, e) => SaveWindowState();
             Application.ApplicationExit += (s, e) => SaveWindowState();
 
             SetupWindowStateTracking();


### PR DESCRIPTION
Про «чутка стёрся config json» из [#3](https://github.com/ComradeBingo/MaxLight/issues/3) — похоже, нашёл механику и починил. Два коммита, ветка от `main` (v1.2.7), поверх твоей локальной 1.2.8 тоже ляжет без конфликтов (эти места между версиями не менялись).

## Механика бага

1. `SaveConfig` пишет через `File.WriteAllText` — запись не атомарна: процесс, убитый посреди записи (а Velopack при `ApplyUpdatesAndRestart` как раз перезапускает приложение), оставляет обрезанный JSON.
2. При рестарте обновления старый и новый процессы могут работать с файлом одновременно — `lock (_lock)` защищает только внутри одного процесса.
3. `LoadConfig` на битом JSON молча возвращает `new ConfigData()` — следующее же сохранение перезаписывает файл дефолтами. Так теряется `Auth` (а логин в MAX живёт именно там — WebView2 запущен в `--incognito`, куки не переживают перезапуск) → перелогин.
4. Усилитель гонки: `this.Move += SaveWindowState` — при перетаскивании окна конфиг перезаписывался десятки раз в секунду (каждый вызов = полный Load+Save). Окно исчезающе малой вероятности превращалось во вполне рабочее.

Это же объясняет, почему у части пользователей всё нормально: нужно совпадение записи конфига с моментом рестарта.

## Что сделано

- **Атомарная запись**: `.tmp` + `FlushFileBuffers` + `File.Replace` — читатель видит либо старый, либо новый файл целиком, прошлая версия остаётся в `config.json.bak`.
- **Восстановление вместо сброса**: битый файл сохраняется как `config.json.corrupt-<дата>` (для диагностики), конфиг поднимается из `.bak` — Auth/PIN/настройки выживают.
- **Межпроцессный `Mutex`** вокруг load/save — от одновременной записи двумя экземплярами при обновлении.
- **Убран `Move`-обработчик**: `ResizeEnd` (WM_EXITSIZEMOVE) срабатывает и в конце перетаскивания, позиция окна сохраняется как раньше.

## Как проверить

- Испортить `config.json` вручную (обрезать половину) → приложение стартует, рядом появляется `.corrupt-*`, настройки восстановлены из `.bak`, перелогина нет.
- Прогнать реальный цикл обновления через Velopack → авторизация выживает.
- Потаскать окно по экрану — конфиг больше не дёргается на каждый пиксель.

Сборка проверена в CI (msbuild, Release). Файлы `.bak`/`.corrupt-*` лежат рядом с `config.json` (корень Velopack) — обновления они переживают.

---

_Диагностика и правки подготовлены Claude (Anthropic) по коду тега v1.2.8 и твоему комментарию в #3. Публикую от аккаунта пользователя._
